### PR TITLE
fix(GlobalStyle) : body에 overscroll 추가

### DIFF
--- a/src/0_App/style/globalStyle.js
+++ b/src/0_App/style/globalStyle.js
@@ -39,6 +39,7 @@ const GlobalStyles = createGlobalStyle`
   body {
   	line-height: 1;
     height: 100%;
+    overscroll-behavior: none;
   }
   #root{
     height: 100%;


### PR DESCRIPTION
overscroll none 속성 이용해 오버레이나 모달 창 띄울때 바운스 되는 효과 제거

https://github.com/user-attachments/assets/0f819c00-469e-4bfa-9847-5bc396a277a9

