### PR TITLE
feat : alertAtom 구현 

### DIFF
--- a/src/0_App/index.js
+++ b/src/0_App/index.js
@@ -7,10 +7,13 @@ import theme from "./style/theme.js";
 import Footer from "./ui/Footer/index.js";
 import STYLE from "./style/style.js";
 import { LoadScript } from "@react-google-maps/api";
+import ConfirmModal from "../2_Widget/ConfirmModal/index.js";
+import useAlertModal from "../4_Shared/Recoil/useAlertModal.js";
 
 const API_KEY = process.env.REACT_APP_GOOGLE_MAP_API_KEY;
 
 const App = () => {
+  const [, isModalOpen, message, closeModal] = useAlertModal();
   return (
     <ThemeProvider theme={theme.defaultTheme}>
       <ResetStyle />
@@ -20,6 +23,9 @@ const App = () => {
           <LoadScript googleMapsApiKey={API_KEY}>
             <Footer />
             <Page />
+            {isModalOpen && (
+              <ConfirmModal type="one" message={message} onClose={closeModal} />
+            )}
           </LoadScript>
         </STYLE.Main>
       </BrowserRouter>

--- a/src/0_App/index.js
+++ b/src/0_App/index.js
@@ -8,7 +8,7 @@ import Footer from "./ui/Footer/index.js";
 import STYLE from "./style/style.js";
 import { LoadScript } from "@react-google-maps/api";
 import ConfirmModal from "../2_Widget/ConfirmModal/index.js";
-import useAlertModal from "../4_Shared/Recoil/useAlertModal.js";
+import useAlertModal from "../4_Shared/Recoil/useAlertModalAtom.js";
 
 const API_KEY = process.env.REACT_APP_GOOGLE_MAP_API_KEY;
 

--- a/src/0_App/index.js
+++ b/src/0_App/index.js
@@ -13,7 +13,7 @@ import useAlertModal from "../4_Shared/Recoil/useAlertModalAtom.js";
 const API_KEY = process.env.REACT_APP_GOOGLE_MAP_API_KEY;
 
 const App = () => {
-  const [, isModalOpen, message, closeModal] = useAlertModal();
+  const [, modalMessage, closeModal] = useAlertModal();
   return (
     <ThemeProvider theme={theme.defaultTheme}>
       <ResetStyle />
@@ -23,8 +23,12 @@ const App = () => {
           <LoadScript googleMapsApiKey={API_KEY}>
             <Footer />
             <Page />
-            {isModalOpen && (
-              <ConfirmModal type="one" message={message} onClose={closeModal} />
+            {modalMessage && (
+              <ConfirmModal
+                type="one"
+                message={modalMessage}
+                onClose={closeModal}
+              />
             )}
           </LoadScript>
         </STYLE.Main>

--- a/src/1_Page/index.js
+++ b/src/1_Page/index.js
@@ -1,3 +1,4 @@
+import React from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import Sns from "./Sns";
 import Profile from "./Profile";
@@ -5,7 +6,7 @@ import Login from "./Login";
 import Search from "./Search";
 import Setting from "./Setting";
 import Tracking from "./Tracking";
-import OAuthRedirect from "./OAuthRedirect"
+import OAuthRedirect from "./OAuthRedirect";
 import STYLE from "./style";
 
 const Page = () => {
@@ -26,4 +27,4 @@ const Page = () => {
   );
 };
 
-export default Page;
+export default React.memo(Page);

--- a/src/4_Shared/Recoil/useAlertModal.js
+++ b/src/4_Shared/Recoil/useAlertModal.js
@@ -1,0 +1,33 @@
+import { atom, useRecoilValue, useSetRecoilState } from "recoil";
+import { useState } from "react";
+
+// 모달 상태를 관리하는 atom (true/false로 모달 열림 여부 관리)
+const isModalOpenAtom = atom({
+  key: "MODAL_OPEN_STATE_ATOM",
+  default: false,
+});
+
+const useAlertModal = () => {
+  const isModalOpen = useRecoilValue(isModalOpenAtom);
+  const setIsModalOpen = useSetRecoilState(isModalOpenAtom);
+  const [message, setMessage] = useState("");
+  const [onCloseAction, setOnCloseAction] = useState(() => () => {});
+
+  // 모달이 닫힐 때 등록된 함수를 호출하고 모달 닫기
+  const closeModal = () => {
+    onCloseAction(); // 등록된 함수 실행
+    setIsModalOpen(false); // 모달 닫기
+  };
+
+  const setAlert = (msg, action) => {
+    setMessage(msg);
+    if (typeof action === "function") {
+      setOnCloseAction(() => action); // 사용자 정의 함수로 저장
+    }
+    setIsModalOpen(true); // 모달 열기
+  };
+
+  return [setAlert, isModalOpen, message, closeModal];
+};
+
+export default useAlertModal;

--- a/src/4_Shared/Recoil/useAlertModalAtom.js
+++ b/src/4_Shared/Recoil/useAlertModalAtom.js
@@ -13,18 +13,17 @@ const useAlertModalAtom = () => {
   const [message, setMessage] = useState("");
   const [onCloseAction, setOnCloseAction] = useState(() => () => {});
 
-  // 모달이 닫힐 때 등록된 함수를 호출하고 모달 닫기
   const closeModal = () => {
-    onCloseAction(); // 등록된 함수 실행
-    setIsModalOpen(false); // 모달 닫기
+    onCloseAction();
+    setIsModalOpen(false);
   };
 
   const setAlert = (msg, action) => {
     setMessage(msg);
     if (typeof action === "function") {
-      setOnCloseAction(() => action); // 사용자 정의 함수로 저장
+      setOnCloseAction(() => action);
     }
-    setIsModalOpen(true); // 모달 열기
+    setIsModalOpen(true);
   };
 
   return [setAlert, isModalOpen, message, closeModal];

--- a/src/4_Shared/Recoil/useAlertModalAtom.js
+++ b/src/4_Shared/Recoil/useAlertModalAtom.js
@@ -7,7 +7,7 @@ const isModalOpenAtom = atom({
   default: false,
 });
 
-const useAlertModal = () => {
+const useAlertModalAtom = () => {
   const isModalOpen = useRecoilValue(isModalOpenAtom);
   const setIsModalOpen = useSetRecoilState(isModalOpenAtom);
   const [message, setMessage] = useState("");
@@ -30,4 +30,4 @@ const useAlertModal = () => {
   return [setAlert, isModalOpen, message, closeModal];
 };
 
-export default useAlertModal;
+export default useAlertModalAtom;

--- a/src/4_Shared/Recoil/useAlertModalAtom.js
+++ b/src/4_Shared/Recoil/useAlertModalAtom.js
@@ -3,7 +3,7 @@ import { atom, useRecoilValue, useSetRecoilState } from "recoil";
 // 모달 메시지 상태 (빈 문자열이면 닫힌 상태로 간주)
 const modalMessageAtom = atom({
   key: "MODAL_MESSAGE_ATOM",
-  default: "",
+  default: null,
 });
 
 // 모달 닫기 동작 상태
@@ -20,7 +20,7 @@ const useAlertModalAtom = () => {
 
   const closeModal = () => {
     onCloseAction();
-    setModalMessage(""); // 모달을 닫을 때 메시지를 초기화
+    setModalMessage(null); // 모달을 닫을 때 메시지를 초기화
   };
 
   const setAlert = (msg, action) => {

--- a/src/4_Shared/Recoil/useAlertModalAtom.js
+++ b/src/4_Shared/Recoil/useAlertModalAtom.js
@@ -20,6 +20,7 @@ const useAlertModalAtom = () => {
 
   const closeModal = () => {
     onCloseAction();
+    setOnCloseAction(() => {});
     setModalMessage(null); // 모달을 닫을 때 메시지를 초기화
   };
 

--- a/src/4_Shared/Recoil/useAlertModalAtom.js
+++ b/src/4_Shared/Recoil/useAlertModalAtom.js
@@ -1,32 +1,38 @@
 import { atom, useRecoilValue, useSetRecoilState } from "recoil";
-import { useState } from "react";
 
-// 모달 상태를 관리하는 atom (true/false로 모달 열림 여부 관리)
-const isModalOpenAtom = atom({
-  key: "MODAL_OPEN_STATE_ATOM",
-  default: false,
+// 모달 메시지 상태 (빈 문자열이면 닫힌 상태로 간주)
+const modalMessageAtom = atom({
+  key: "MODAL_MESSAGE_ATOM",
+  default: "",
+});
+
+// 모달 닫기 동작 상태
+const onCloseActionAtom = atom({
+  key: "MODAL_CLOSE_ACTION_ATOM",
+  default: () => {},
 });
 
 const useAlertModalAtom = () => {
-  const isModalOpen = useRecoilValue(isModalOpenAtom);
-  const setIsModalOpen = useSetRecoilState(isModalOpenAtom);
-  const [message, setMessage] = useState("");
-  const [onCloseAction, setOnCloseAction] = useState(() => () => {});
+  const modalMessage = useRecoilValue(modalMessageAtom);
+  const setModalMessage = useSetRecoilState(modalMessageAtom);
+  const setOnCloseAction = useSetRecoilState(onCloseActionAtom);
+  const onCloseAction = useRecoilValue(onCloseActionAtom);
 
   const closeModal = () => {
     onCloseAction();
-    setIsModalOpen(false);
+    setModalMessage(""); // 모달을 닫을 때 메시지를 초기화
   };
 
   const setAlert = (msg, action) => {
-    setMessage(msg);
+    setModalMessage(msg);
     if (typeof action === "function") {
       setOnCloseAction(() => action);
+    } else {
+      setOnCloseAction(() => {});
     }
-    setIsModalOpen(true);
   };
 
-  return [setAlert, isModalOpen, message, closeModal];
+  return [setAlert, modalMessage, closeModal];
 };
 
 export default useAlertModalAtom;


### PR DESCRIPTION
사용 setAlert("message",function)으로 oneBtnModal 열리는 함수 구현 
page의 memo이용해 modal에 따른 렌더링 최적화 
모달 상태를 전역으로 관리 
setAlert이용해 어디서든 모달 출력 가능하도록 구현해봤습니다 피드백 주시면 반영하겠습니다 감사합니다

```
  const setAlert = (msg, action) => {
    setMessage(msg);
    if (typeof action === "function") {
      setOnCloseAction(() => action);
    }
    setIsModalOpen(true);
  };
```

예상효과 
```
      switch (status) {
        case 401:
        case 403:
          alert("로그인이 필요합니다!");
          navigate("/login");
          break;
```

```
      switch (status) {
        case 401:
        case 403:
          setAlert("로그인이 필요합니다", () => {
            navigate("/login");
          });
          break;
```
alert메시지 -> modal 로 ui적 이득이 예상됩니다 